### PR TITLE
Fix: Prevent tablist from remaining fixed on scroll to top

### DIFF
--- a/src/app/menu/page.tsx
+++ b/src/app/menu/page.tsx
@@ -21,7 +21,7 @@ export default function MenuPage() {
   const [isReady, setIsReady] = useState(false);
   const [activeCategory, setActiveCategory] = useState<string>("");
   const categoryRefs = useRef<{[key: string]: HTMLDivElement | null}>({});
-  const tabListRef = useRef<HTMLDivElement | null>(null);
+  const headerRef = useRef<HTMLDivElement | null>(null);
   
   // Fetch restaurant profile
   const { restaurantData } = useRestaurantProfile(DEFAULT_RESTAURANT_ID);
@@ -67,9 +67,9 @@ useEffect(() => {
   const handleScroll = () => {
     const tabList = document.querySelector('.tablist');
 
-    if (tabListRef.current && tabList) {
-      const tabListRect = tabListRef.current.getBoundingClientRect();
-      const isFixed = tabListRect.top <= 0;
+    if (headerRef.current && tabList) {
+      const headerRect = headerRef.current.getBoundingClientRect();
+      const isFixed = headerRect.bottom <= 0;
 
       if (isFixed) {
         tabList.classList.add('fixed');
@@ -156,14 +156,12 @@ useEffect(() => {
         }}
       >
         <MenuStyle>
-          <Header logoId={restaurantData?.data?.logoIds?.[0]} />
-          <div ref={tabListRef}>
-        <TabList 
-          categories={finalMenuData?.data || []} 
-          activeCategory={activeCategory}
-          onTabClick={handleTabClick}
-        />
-      </div>
+          <Header ref={headerRef} logoId={restaurantData?.data?.logoIds?.[0]} />
+          <TabList
+            categories={finalMenuData?.data || []}
+            activeCategory={activeCategory}
+            onTabClick={handleTabClick}
+          />
       {finalMenuData?.data?.map((category) => (
         <div 
           key={category._id} 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import Image from "next/image";
 import Cloud from "@/app/assets/icons/Cloud.png";
 import LogoFinal from "@/app/assets/icons/LogoFinal.png";
@@ -10,12 +11,12 @@ interface HeaderProps {
   logoId?: string;
 }
 
-export default function Header({ logoId }: HeaderProps) {
+const Header = React.forwardRef<HTMLDivElement, HeaderProps>(({ logoId }, ref) => {
   // Use the logo from API if available, otherwise use default LogoFinal
   const logoSrc = logoId && logoId !== '' ? getImageUrl(logoId) : LogoFinal;
   
   return (
-    <HeaderContainer>
+    <HeaderContainer ref={ref}>
       <Clouds>
         <CloudLeft>
           <Image src={Cloud} alt="Cloud left" width={640} height={320} priority style={{ width: "100%", height: "auto" }} />
@@ -36,6 +37,10 @@ export default function Header({ logoId }: HeaderProps) {
       </Clouds>
     </HeaderContainer>
   );
-}
+});
+
+Header.displayName = "Header";
+
+export default Header;
 
 


### PR DESCRIPTION
The tablist was not reliably becoming unfixed when scrolling back to the top of the page. This was due to an unreliable method of detecting the scroll position using a wrapper div that would collapse.

This change refactors the scroll detection logic to use the Header component as a stable reference point. The Header component is modified to accept a forwarded ref, and the scroll handler in the MenuPage now checks for the bottom of the header to leave the viewport before making the tablist fixed. This ensures the tablist's sticky state is toggled correctly.