### PR TITLE
feat: Implement list virtualization on menu page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,14 @@
         "@radix-ui/react-dialog": "^1.1.14",
         "@reduxjs/toolkit": "^2.8.2",
         "@shadcn/ui": "^0.0.4",
+        "@types/react-window": "^1.8.8",
         "axios": "^1.11.0",
         "next": "15.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-icons": "^5.5.0",
-        "react-redux": "^9.2.0"
+        "react-redux": "^9.2.0",
+        "react-window": "^1.8.11"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2273,6 +2275,15 @@
       "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
       "license": "MIT",
       "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
+      "license": "MIT",
+      "dependencies": {
         "@types/react": "*"
       }
     },
@@ -6000,6 +6011,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -6892,6 +6909,23 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -16,12 +16,14 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@reduxjs/toolkit": "^2.8.2",
     "@shadcn/ui": "^0.0.4",
+    "@types/react-window": "^1.8.8",
     "axios": "^1.11.0",
     "next": "15.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-icons": "^5.5.0",
-    "react-redux": "^9.2.0"
+    "react-redux": "^9.2.0",
+    "react-window": "^1.8.11"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
Refactors the menu page to use `react-window` for list virtualization. This addresses a critical performance issue where the browser would crash when scrolling through the long list of menu items.

The previous implementation rendered all category sections and items at once, causing significant performance degradation and crashes on long scrolls. This has been replaced with a `VariableSizeList` that only renders the items currently visible in the viewport.

This change includes:
- Adding `react-window` as a dependency.
- A complete refactor of the rendering logic in `MenuPage` to use the virtualized list.
- A custom height estimation function for the variable-sized category sections.
- A new mechanism to determine the active category based on the scroll offset within the virtualized list.
- Removal of the old, buggy scroll handling logic, including the logic for the fixed tablist, which is no longer necessary with the new layout.